### PR TITLE
Handle out of bounds error

### DIFF
--- a/src/core/cellbuffer.rs
+++ b/src/core/cellbuffer.rs
@@ -12,6 +12,7 @@ use std::iter::Iterator;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CellBuffer {
     vec: Vec<Vec<Cell>>,
+    dummy_cell: Cell, // cell for out of bounds access
 }
 
 impl CellBuffer {
@@ -20,6 +21,7 @@ impl CellBuffer {
     pub fn new(cols: usize, rows: usize, cell: Cell) -> CellBuffer {
         CellBuffer {
             vec: vec![vec![cell; cols]; rows],
+            dummy_cell: cell,
         }
     }
 
@@ -69,11 +71,42 @@ impl Index<usize> for CellBuffer {
     }
 }
 
+impl Index<(usize, usize)> for CellBuffer {
+    type Output = Cell;
+
+    fn index<'a>(&'a self, index: (usize, usize)) -> &'a Cell {
+        let (y, x) = index;
+        if y >= self.vec.len() {
+            return &self.dummy_cell
+        }
+        let row = &self.vec[y];
+        if x >= row.len() {
+            return &self.dummy_cell
+        }
+        &row[x]
+    }
+}
+
 impl IndexMut<usize> for CellBuffer {
     fn index_mut(&mut self, index: usize) -> &mut Vec<Cell> {
         &mut self.vec[index]
     }
 }
+
+impl IndexMut<(usize, usize)> for CellBuffer {
+    fn index_mut(&mut self, index: (usize, usize)) -> &mut Cell {
+        let (y, x) = index;
+        if y >= self.vec.len() {
+            return &mut self.dummy_cell
+        }
+        let mut row = &mut self.vec[y];
+        if x >= row.len() {
+            return &mut self.dummy_cell
+        }
+        &mut row[x]
+    }
+}
+
 
 /// A single point on a terminal display.
 ///

--- a/src/core/terminal.rs
+++ b/src/core/terminal.rs
@@ -61,15 +61,15 @@ type EventBuffer = VecDeque<Event>;
 /// let mut term = Terminal::new().unwrap();
 ///
 /// // Terminals can be indexed to access specific cells.
-/// // Indices are by column then row, corresponding to a cell's x and y coordinates.
-/// term[0][0] = Cell::with_char('x');
-/// assert_eq!(term[0][0].ch(), 'x');
+/// // Indices are by row then column, corresponding to a cell's y and x coordinates.
+/// term[(0, 0)] = Cell::with_char('x');
+/// assert_eq!(term[(0, 0)].ch(), 'x');
 ///
-/// term[0][1].set_bg(Style::with_color(Color::Red));
-/// assert_eq!(term[0][1].bg(), Style::with_color(Color::Red));
+/// term[(0, 1)].set_bg(Style::with_color(Color::Red));
+/// assert_eq!(term[(0, 1)].bg(), Style::with_color(Color::Red));
 ///
-/// term[0][2].fg_mut().set_color(Color::Blue);
-/// assert_eq!(term[0][2].fg().color(), Color::Blue);
+/// term[(0, 2)].fg_mut().set_color(Color::Blue);
+/// assert_eq!(term[(0, 2)].fg().color(), Color::Blue);
 /// ```
 pub struct Terminal {
     orig_tios: termios::Termios, // Original underlying terminal state.
@@ -748,8 +748,22 @@ impl Index<usize> for Terminal {
     }
 }
 
+impl Index<(usize, usize)> for Terminal {
+    type Output = Cell;
+
+    fn index<'a>(&'a self, index: (usize, usize)) -> &'a Cell {
+        &self.backbuffer[index]
+    }
+}
+
 impl IndexMut<usize> for Terminal {
     fn index_mut(&mut self, index: usize) -> &mut Vec<Cell> {
+        &mut self.backbuffer[index]
+    }
+}
+
+impl IndexMut<(usize, usize)> for Terminal {
+    fn index_mut(&mut self, index: (usize, usize)) -> &mut Cell {
         &mut self.backbuffer[index]
     }
 }


### PR DESCRIPTION
Accessing out of bounds indexes would make us panic (without message
because of our messing up with the TTY). This commits handles out of
bounds errors be returning a dummy cell.

This required to change the indexing API from `term[y][x]` to `term[(y,
x)]` because otherwise, we would have had to override `Vec`'s indexing
methods (our rows are plain vectors and although our first indexing go
through `CellBuffer`'s indexing implementation, our second indexing is
handled directly by `Vec`).

The old API was left there for now, to avoid breakeage.

@cpjreynolds, what do you think of the proposed indexing API? Is there a particular reason why `term[y][x]` was chosen instead of `term[(y, x)]` in the first place?