### PR TITLE
implement generic error struct

### DIFF
--- a/src/core/driver.rs
+++ b/src/core/driver.rs
@@ -115,7 +115,7 @@ fn get_tinfo() -> Result<&'static TermInfo> {
 
     for capname in CAPABILITIES {
         if !tinfo.strings.contains_key(*capname) {
-            return Err(Error::new(&format!("terminal missing capability: '{}'", capname)));
+            return Err(Error::new(format!("terminal missing capability: '{}'", capname)));
         }
     }
     Ok(tinfo)

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -11,10 +11,6 @@ pub type Result<T> = result::Result<T, Error>;
 /// An error arising from terminal operations.
 ///
 /// The lower-level cause of the error, if any, will be returned by calling `cause()`.
-///
-/// **Note:** Errors arising from system calls will return `None` when calling `cause()` as `nix`
-/// errors do not implement `Error`. In this case, `description()` will return the standard `errno`
-/// description.
 #[derive(Debug)]
 pub struct Error {
     err: Box<StdError + Send + Sync>,

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -4,7 +4,6 @@ use std::io;
 use std::error::Error as StdError;
 use std::result;
 
-use term::terminfo;
 use nix;
 
 pub type Result<T> = result::Result<T, Error>;
@@ -18,63 +17,45 @@ pub type Result<T> = result::Result<T, Error>;
 /// description.
 #[derive(Debug)]
 pub struct Error {
-    desc: String,
-    cause: Option<Box<StdError>>,
+    err: Box<StdError + Send + Sync>,
 }
 
 impl Error {
-    pub fn new(desc: &str) -> Error {
+    pub fn new<E>(error: E) -> Error
+        where E: Into<Box<StdError + Send + Sync>>
+    {
+        let err = error.into();
         Error {
-            desc: String::from(desc),
-            cause: None,
+            err: err,
         }
     }
 }
 
 impl StdError for Error {
     fn description(&self) -> &str {
-        &self.desc[..]
+        self.err.description()
     }
 
     fn cause(&self) -> Option<&StdError> {
-        if let Some(ref err) = self.cause {
-            Some(&**err)
-        } else {
-            None
-        }
+        self.err.cause()
     }
 }
 
 impl From<nix::Error> for Error {
     fn from(err: nix::Error) -> Self {
-        Error {
-            desc: String::from(err.errno().desc()),
-            cause: None,
-        }
+        Error::new(err.errno().desc())
     }
 }
 
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Self {
-        Error {
-            desc: String::from(err.description()),
-            cause: Some(Box::new(err)),
-        }
-    }
-}
-
-impl From<terminfo::Error> for Error {
-    fn from(err: terminfo::Error) -> Self {
-        Error {
-            desc: String::from(err.description()),
-            cause: Some(Box::new(err)),
-        }
+        Error::new(err)
     }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.desc)
+        self.err.fmt(f)
     }
 }
 


### PR DESCRIPTION
This pull request implements a more generic error structure for rustty.

The design is based on that of `std::io::Error` and offers much more flexibility in passing error payloads.