### PR TITLE
Flatten Cell's structure

### DIFF
--- a/examples/textedit.rs
+++ b/examples/textedit.rs
@@ -3,14 +3,13 @@ extern crate rustty;
 use rustty::{
     Terminal,
     Event,
-    Style,
     Color,
 };
 
 struct Cursor {
     pos: Position,
     lpos: Position,
-    style: Style,
+    color: Color,
 }
 
 #[derive(Copy, Clone)]
@@ -23,10 +22,10 @@ fn main() {
     let mut cursor = Cursor {
         pos: Position { x: 0, y: 0 },
         lpos: Position { x: 0, y: 0 },
-        style: Style::with_color(Color::Red),
+        color: Color::Red,
     };
     let mut term = Terminal::new().unwrap();
-    term[(cursor.pos.x, cursor.pos.y)].set_bg(cursor.style);
+    term[(cursor.pos.x, cursor.pos.y)].set_bg(cursor.color);
     term.swap_buffers().unwrap();
     loop {
         let evt = term.get_event(100).unwrap();
@@ -56,19 +55,19 @@ fn main() {
                 },
             }
             if cursor.pos.x >= term.cols()-1 {
-                term[(cursor.lpos.x, cursor.lpos.y)].set_bg(Style::default());
+                term[(cursor.lpos.x, cursor.lpos.y)].set_bg(Color::Default);
                 cursor.lpos = cursor.pos;
                 cursor.pos.x = 0;
                 cursor.pos.y += 1;
             }
             if cursor.pos.y >= term.rows()-1 {
-                term[(cursor.lpos.x, cursor.lpos.y)].set_bg(Style::default());
+                term[(cursor.lpos.x, cursor.lpos.y)].set_bg(Color::Default);
                 cursor.lpos = cursor.pos;
                 cursor.pos.x = 0;
                 cursor.pos.y = 0;
             }
-            term[(cursor.lpos.x, cursor.lpos.y)].set_bg(Style::default());
-            term[(cursor.pos.x, cursor.pos.y)].set_bg(cursor.style);
+            term[(cursor.lpos.x, cursor.lpos.y)].set_bg(Color::Default);
+            term[(cursor.pos.x, cursor.pos.y)].set_bg(cursor.color);
             term.swap_buffers().unwrap();
         }
     }

--- a/src/core/cellbuffer.rs
+++ b/src/core/cellbuffer.rs
@@ -111,65 +111,70 @@ impl Default for CellBuffer {
 
 /// A single point on a terminal display.
 ///
-/// A `Cell` contains a character and a set of foreground and background `Style`s.
+/// A `Cell` contains a character and style.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Cell {
     ch: char,
-    fg: Style,
-    bg: Style,
+    fg: Color,
+    bg: Color,
+    attrs: Attr,
 }
 
 impl Cell {
-    /// Creates a new `Cell` with the given `char` and `Style`s.
+    /// Creates a new `Cell` with the given `char`, `Color`s and `Attr`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rustty::{Cell, Style, Color};
+    /// use rustty::{Cell, Color, Attr};
     ///
-    /// let mut cell = Cell::new('x', Style::default(), Style::with_color(Color::Green));
+    /// let cell = Cell::new('x', Color::Default, Color::Green, Attr::Default);
     /// assert_eq!(cell.ch(), 'x');
-    /// assert_eq!(cell.fg(), Style::default());
-    /// assert_eq!(cell.bg(), Style::with_color(Color::Green));
+    /// assert_eq!(cell.fg(), Color::Default);
+    /// assert_eq!(cell.bg(), Color::Green);
+    /// assert_eq!(cell.attrs(), Attr::Default);
     /// ```
-    pub fn new(ch: char, fg: Style, bg: Style) -> Cell {
+    pub fn new(ch: char, fg: Color, bg: Color, attrs: Attr) -> Cell {
         Cell {
             ch: ch,
             fg: fg,
             bg: bg,
+            attrs: attrs,
         }
     }
 
-    /// Creates a new `Cell` with the given `char` and default `Style`s.
+    /// Creates a new `Cell` with the given `char` and default style.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rustty::{Cell, Style};
+    /// use rustty::{Cell, Color, Attr};
     ///
     /// let mut cell = Cell::with_char('x');
     /// assert_eq!(cell.ch(), 'x');
-    /// assert_eq!(cell.fg(), Style::default());
-    /// assert_eq!(cell.bg(), Style::default());
+    /// assert_eq!(cell.fg(), Color::Default);
+    /// assert_eq!(cell.bg(), Color::Default);
+    /// assert_eq!(cell.attrs(), Attr::Default);
     /// ```
     pub fn with_char(ch: char) -> Cell {
-        Cell::new(ch, Style::default(), Style::default())
+        Cell::new(ch, Color::Default, Color::Default, Attr::Default)
     }
 
-    /// Creates a new `Cell` with the given `Style`s and a blank `char`.
+    /// Creates a new `Cell` with the given style and a blank `char`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rustty::{Cell, Style, Color};
+    /// use rustty::{Cell, Color, Attr};
     ///
-    /// let mut cell = Cell::with_styles(Style::default(), Style::with_color(Color::Red));
-    /// assert_eq!(cell.fg(), Style::default());
-    /// assert_eq!(cell.bg(), Style::with_color(Color::Red));
+    /// let mut cell = Cell::with_style(Color::Default, Color::Red, Attr::Bold);
+    /// assert_eq!(cell.fg(), Color::Default);
+    /// assert_eq!(cell.bg(), Color::Red);
+    /// assert_eq!(cell.attrs(), Attr::Bold);
     /// assert_eq!(cell.ch(), ' ');
     /// ```
-    pub fn with_styles(fg: Style, bg: Style) -> Cell {
-        Cell::new(' ', fg, bg)
+    pub fn with_style(fg: Color, bg: Color, attr: Attr) -> Cell {
+        Cell::new(' ', fg, bg, attr)
     }
 
     /// Returns the `Cell`'s character.
@@ -204,256 +209,101 @@ impl Cell {
         self
     }
 
-    /// Returns the `Cell`'s foreground `Style`.
+    /// Returns the `Cell`'s foreground `Color`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rustty::{Cell, Style, Attr};
+    /// use rustty::{Cell, Color, Attr};
     ///
-    /// let mut cell = Cell::with_styles(Style::with_attr(Attr::Bold), Style::default());
-    /// assert_eq!(cell.fg(), Style::with_attr(Attr::Bold));
+    /// let mut cell = Cell::with_style(Color::Blue, Color::Default, Attr::Default);
+    /// assert_eq!(cell.fg(), Color::Blue);
     /// ```
-    pub fn fg(&self) -> Style {
+    pub fn fg(&self) -> Color {
         self.fg
     }
 
-    /// Returns a mutable reference to the `Cell`'s foreground `Style`.
+    /// Sets the `Cell`'s foreground `Color` to the given `Color`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rustty::{Cell, Style};
+    /// use rustty::{Cell, Color, Attr};
     ///
     /// let mut cell = Cell::default();
-    /// assert_eq!(cell.fg_mut(), &mut Style::default());
+    /// assert_eq!(cell.fg(), Color::Default);
+    ///
+    /// cell.set_fg(Color::White);
+    /// assert_eq!(cell.fg(), Color::White);
     /// ```
-    pub fn fg_mut(&mut self) -> &mut Style {
-        &mut self.fg
-    }
-
-    /// Sets the `Cell`'s foreground `Style` to the given `Style`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rustty::{Cell, Style, Color, Attr};
-    ///
-    /// let mut cell = Cell::with_styles(Style::with_color(Color::Green), Style::default());
-    /// assert_eq!(cell.fg(), Style::with_color(Color::Green));
-    ///
-    /// cell.set_fg(Style::with_attr(Attr::Underline));
-    /// assert_eq!(cell.fg(), Style::with_attr(Attr::Underline));
-    /// ```
-    pub fn set_fg(&mut self, newfg: Style) -> &mut Cell {
+    pub fn set_fg(&mut self, newfg: Color) -> &mut Cell {
         self.fg = newfg;
         self
     }
 
-    /// Returns the `Cell`'s background `Style`.
+    /// Returns the `Cell`'s background `Color`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rustty::{Cell, Style, Attr};
+    /// use rustty::{Cell, Color, Attr};
     ///
-    /// let mut cell = Cell::with_styles(Style::default(), Style::with_attr(Attr::Bold));
-    /// assert_eq!(cell.bg(), Style::with_attr(Attr::Bold));
+    /// let mut cell = Cell::with_style(Color::Default, Color::Green, Attr::Default);
+    /// assert_eq!(cell.bg(), Color::Green);
     /// ```
-    pub fn bg(&self) -> Style {
+    pub fn bg(&self) -> Color {
         self.bg
     }
 
-    /// Returns a mutable reference to the `Cell`'s background `Style`.
+    /// Sets the `Cell`'s background `Color` to the given `Color`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rustty::{Cell, Style};
+    /// use rustty::{Cell, Color, Attr};
     ///
     /// let mut cell = Cell::default();
-    /// assert_eq!(cell.bg_mut(), &mut Style::default());
+    /// assert_eq!(cell.bg(), Color::Default);
+    ///
+    /// cell.set_bg(Color::Black);
+    /// assert_eq!(cell.bg(), Color::Black);
     /// ```
-    pub fn bg_mut(&mut self) -> &mut Style {
-        &mut self.bg
+    pub fn set_bg(&mut self, newbg: Color) -> &mut Cell {
+        self.bg = newbg;
+        self
     }
 
-    /// Sets the `Cell`'s background `Style` to the given `Style`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rustty::{Cell, Style, Color, Attr};
-    ///
-    /// let mut cell = Cell::with_styles(Style::default(), Style::with_color(Color::Green));
-    /// assert_eq!(cell.bg(), Style::with_color(Color::Green));
-    ///
-    /// cell.set_bg(Style::with_attr(Attr::Underline));
-    /// assert_eq!(cell.bg(), Style::with_attr(Attr::Underline));
-    /// ```
-    pub fn set_bg(&mut self, newbg: Style) -> &mut Cell {
-        self.bg = newbg;
+    pub fn attrs(&self) -> Attr {
+        self.attrs
+    }
+
+    pub fn set_attrs(&mut self, newattrs: Attr) -> &mut Cell {
+        self.attrs = newattrs;
         self
     }
 }
 
 impl Default for Cell {
-    /// Constructs a new `Cell` with a blank `char` and default `Style`s.
+    /// Constructs a new `Cell` with a blank `char` and default `Color`s.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rustty::{Cell, Style};
+    /// use rustty::{Cell, Color};
     ///
     /// let mut cell = Cell::default();
     /// assert_eq!(cell.ch(), ' ');
-    /// assert_eq!(cell.fg(), Style::default());
-    /// assert_eq!(cell.bg(), Style::default());
+    /// assert_eq!(cell.fg(), Color::Default);
+    /// assert_eq!(cell.bg(), Color::Default);
     /// ```
     fn default() -> Cell {
-        Cell::new(' ', Style::default(), Style::default())
-    }
-}
-
-/// The style of a `Cell`.
-///
-/// A `Style` has a `Color` and an `Attr` and represents either the foreground or background
-/// styling of a `Cell`.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct Style(Color, Attr);
-
-impl Style {
-    /// Constructs a new `Style` with the given `Color` and `Attr`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rustty::{Style, Color, Attr};
-    ///
-    /// let mut style = Style::new(Color::Green, Attr::BoldUnderline);
-    /// assert_eq!(style.color(), Color::Green);
-    /// assert_eq!(style.attr(), Attr::BoldUnderline);
-    /// ```
-    pub fn new(color: Color, attr: Attr) -> Style {
-        Style(color, attr)
-    }
-
-    /// Constructs a new `Style` with the given `Color` and the default `Attr`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rustty::{Style, Color, Attr};
-    ///
-    /// let mut style = Style::with_color(Color::Cyan);
-    /// assert_eq!(style.color(), Color::Cyan);
-    /// assert_eq!(style.attr(), Attr::Default);
-    /// ```
-    pub fn with_color(c: Color) -> Style {
-        Style::new(c, Attr::Default)
-    }
-
-    /// Constructs a new `Style` with the given `Attr` and the default `Color`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rustty::{Style, Color, Attr};
-    ///
-    /// let mut style = Style::with_attr(Attr::UnderlineReverse);
-    /// assert_eq!(style.attr(), Attr::UnderlineReverse);
-    /// assert_eq!(style.color(), Color::Default);
-    /// ```
-    pub fn with_attr(a: Attr) -> Style {
-        Style::new(Color::Default, a)
-    }
-
-    /// Returns the `Style`'s `Color`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rustty::{Style, Color};
-    ///
-    /// let mut style = Style::with_color(Color::Yellow);
-    /// assert_eq!(style.color(), Color::Yellow);
-    /// ```
-    pub fn color(&self) -> Color {
-        self.0
-    }
-
-    /// Sets the `Style`'s `Color` to the given `Color`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rustty::{Style, Color};
-    ///
-    /// let mut style = Style::with_color(Color::White);
-    /// assert_eq!(style.color(), Color::White);
-    ///
-    /// style.set_color(Color::Black);
-    /// assert_eq!(style.color(), Color::Black);
-    /// ```
-    pub fn set_color(&mut self, newcolor: Color) -> &mut Style {
-        self.0 = newcolor;
-        self
-    }
-
-    /// Returns the `Style`'s `Attr`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rustty::{Style, Attr};
-    ///
-    /// let mut style = Style::with_attr(Attr::Reverse);
-    /// assert_eq!(style.attr(), Attr::Reverse);
-    /// ```
-    pub fn attr(&self) -> Attr {
-        self.1
-    }
-
-    /// Sets the given `Style`'s `Attr` to the given `Attr`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rustty::{Style, Attr};
-    ///
-    /// let mut style = Style::with_attr(Attr::BoldReverse);
-    /// assert_eq!(style.attr(), Attr::BoldReverse);
-    ///
-    /// style.set_attr(Attr::Underline);
-    /// assert_eq!(style.attr(), Attr::Underline);
-    /// ```
-    pub fn set_attr(&mut self, newattr: Attr) -> &mut Style {
-        self.1 = newattr;
-        self
-    }
-}
-
-impl Default for Style {
-    /// Constructs a new `Style` with the default `Color` and `Attr`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rustty::{Style, Color, Attr};
-    ///
-    /// let mut style = Style::default();
-    /// assert_eq!(style.color(), Color::Default);
-    /// assert_eq!(style.attr(), Attr::Default);
-    /// ```
-    fn default() -> Style {
-        Style::new(Color::Default, Attr::Default)
+        Cell::new(' ', Color::Default, Color::Default, Attr::Default)
     }
 }
 
 /// The color of a `Cell`.
 ///
-/// `Color::Default` represents the default color of the underlying terminal and may be used to
-/// reset a `Style`'s `Color`.
+/// `Color::Default` represents the default color of the underlying terminal.
 ///
 /// The eight basic colors may be used directly and correspond to 0x00..0x07 in the 8-bit (256)
 /// color range; in addition, the eight basic colors coupled with `Attr::Bold` correspond to
@@ -512,9 +362,9 @@ impl Color {
 
 /// The attributes of a `Cell`.
 ///
-/// `Attr` enumerates all combinations of attributes a given `Style` may have.
+/// `Attr` enumerates all combinations of attributes a given style may have.
 ///
-/// `Attr::Default` represents no attribute and may be used to reset a `Style`'s `Attr`.
+/// `Attr::Default` represents no attribute.
 ///
 /// # Examples
 ///

--- a/src/core/driver.rs
+++ b/src/core/driver.rs
@@ -50,6 +50,7 @@ static CAPABILITIES: &'static [&'static str] = &[
 // to take advantage of compile-time type-checking instead of hoping invalid strings aren't passed.
 // This allows us to guarantee that driver accesses will succeed. In addition, using an enum means
 // Driver doesn't need hard-coded methods for each capability we want to use.
+#[allow(dead_code)]
 pub enum DevFn {
     EnterCa,
     ExitCa,

--- a/src/core/terminal.rs
+++ b/src/core/terminal.rs
@@ -19,7 +19,7 @@ use nix::sys::epoll::{EpollOp, EpollEvent, EpollEventKind};
 use nix::sys::epoll;
 use nix::errno::Errno;
 
-use core::cellbuffer::{CellBuffer, Cell, Style, Color, Attr};
+use core::cellbuffer::{CellBuffer, Cell, Color, Attr};
 use core::input::Event;
 use core::position::{Position, Coordinate, Cursor, Pair};
 use core::driver::{
@@ -49,7 +49,7 @@ type EventBuffer = VecDeque<Event>;
 /// # Examples
 ///
 /// ```no_run
-/// use rustty::{Terminal, Cell, Style, Color};
+/// use rustty::{Terminal, Cell, Color};
 ///
 /// // Construct a new Terminal.
 /// let mut term = Terminal::new().unwrap();
@@ -59,11 +59,11 @@ type EventBuffer = VecDeque<Event>;
 /// term[(0, 0)] = Cell::with_char('x');
 /// assert_eq!(term[(0, 0)].ch(), 'x');
 ///
-/// term[(0, 1)].set_bg(Style::with_color(Color::Red));
-/// assert_eq!(term[(0, 1)].bg(), Style::with_color(Color::Red));
+/// term[(0, 1)].set_bg(Color::Red);
+/// assert_eq!(term[(0, 1)].bg(), Color::Red);
 ///
-/// term[(0, 2)].fg_mut().set_color(Color::Blue);
-/// assert_eq!(term[(0, 2)].fg().color(), Color::Blue);
+/// term[(0, 2)].set_fg(Color::Blue);
+/// assert_eq!(term[(0, 2)].fg(), Color::Blue);
 /// ```
 pub struct Terminal {
     termctl: TermCtl,
@@ -76,8 +76,7 @@ pub struct Terminal {
     frontbuffer: CellBuffer, // Internal frontbuffer.
     outbuffer: OutBuffer, // Internal output buffer.
     eventbuffer: EventBuffer, // Event buffer.
-    lastfg: Style, // Last foreground style written to the output buffer.
-    lastbg: Style, // Last background style written to the input buffer.
+    laststyle: Cell, // Last cell to have its style (fg, bg, attrs) written to the output buffer.
     cursor: Cursor, // Current cursor position.
 }
 
@@ -109,25 +108,6 @@ impl Terminal {
     /// ```
     pub fn with_char(ch: char) -> Result<Terminal, Error> {
         Terminal::with_cell(Cell::with_char(ch))
-    }
-
-    /// Constructs a new `Terminal` with each cell set to the given `Style`s and a blank `char`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use rustty::{Terminal, Cell, Style, Color, Attr};
-    ///
-    /// let style1 = Style::with_color(Color::Blue);
-    /// let style2 = Style::with_attr(Attr::Reverse);
-    ///
-    /// let mut term = Terminal::with_styles(style1, style2).unwrap();
-    /// assert_eq!(term[(0, 0)].fg(), Style::with_color(Color::Blue));
-    /// assert_eq!(term[(0, 0)].bg(), Style::with_attr(Attr::Reverse));
-    /// assert_eq!(term[(0, 0)].ch(), ' ');
-    /// ```
-    pub fn with_styles(fg: Style, bg: Style) -> Result<Terminal, Error> {
-        Terminal::with_cell(Cell::with_styles(fg, bg))
     }
 
     /// Creates a new `Terminal` using the given cell as a blank.
@@ -188,8 +168,7 @@ impl Terminal {
             frontbuffer: CellBuffer::new(0, 0, cell),
             outbuffer: OutBuffer::with_capacity(32 * 1024),
             eventbuffer: EventBuffer::with_capacity(128),
-            lastfg: cell.fg(),
-            lastbg: cell.bg(),
+            laststyle: cell,
             cursor: Cursor::new(),
         };
 
@@ -232,7 +211,7 @@ impl Terminal {
                     continue; // Don't redraw cells that haven't changed.
                 } else {
                     let cell = self.backbuffer[(x, y)];
-                    try!(self.send_style(cell.fg(), cell.bg()));
+                    try!(self.send_style(cell));
                     try!(self.send_char(Coordinate::Valid((x, y)), cell.ch()));
                     self.frontbuffer[(x, y)] = cell;
                 }
@@ -327,33 +306,6 @@ impl Terminal {
             try!(self.resize());
         }
         self.backbuffer.clear(Cell::with_char(ch));
-        Ok(())
-    }
-
-    /// Clears the internal backbuffer with the given `Style`s and a blank `char`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use rustty::{Terminal, Cell, Style, Color};
-    ///
-    /// let mut style1 = Style::with_color(Color::Blue);
-    /// let mut style2 = Style::with_color(Color::Red);
-    ///
-    /// let mut term = Terminal::with_styles(style1, style2).unwrap();
-    /// assert_eq!(term[(0, 0)].fg(), Style::with_color(Color::Blue));
-    /// assert_eq!(term[(0, 0)].bg(), Style::with_color(Color::Red));
-    ///
-    /// term.clear_with_styles(style2, style1).unwrap();
-    /// assert_eq!(term[(0, 0)].fg(), Style::with_color(Color::Red));
-    /// assert_eq!(term[(0, 0)].bg(), Style::with_color(Color::Blue));
-    /// ```
-    pub fn clear_with_styles(&mut self, fg: Style, bg: Style) -> Result<(), Error> {
-        // Check whether the window has been resized; if it has then update and resize the buffers.
-        if SIGWINCH_STATUS.compare_and_swap(true, false, Ordering::SeqCst) {
-            try!(self.resize());
-        }
-        self.backbuffer.clear(Cell::with_styles(fg, bg));
         Ok(())
     }
 
@@ -486,28 +438,6 @@ impl Terminal {
     }
 
     /// Resizes the buffers if the underlying terminal window size has changed, using the given
-    /// `Style`s and a blank `char` as a blank.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use rustty::{Terminal, Style, Color};
-    ///
-    /// let style = Style::with_color(Color::Red);
-    ///
-    /// let mut term = Terminal::new().unwrap();
-    ///
-    /// // If new_size == Some(T) then T is the new size of the terminal.
-    /// // If new_size == None then the terminal has not resized.
-    /// let new_size = term.try_resize_with_styles(style, style).unwrap();
-    /// ```
-    pub fn try_resize_with_styles(&mut self,
-                                  fg: Style,
-                                  bg: Style) -> Result<Option<(usize, usize)>, Error> {
-        self.try_resize_with_cell(Cell::with_styles(fg, bg))
-    }
-
-    /// Resizes the buffers if the underlying terminal window size has changed, using the given
     /// `Cell` as a blank.
     ///
     /// # Examples
@@ -621,8 +551,7 @@ impl Terminal {
         Ok(())
     }
 
-    fn send_clear(&mut self, fg: Style, bg: Style) -> Result<(), Error> {
-        try!(self.send_style(fg, bg));
+    fn send_clear(&mut self) -> Result<(), Error> {
         try!(self.outbuffer.write_all(&self.driver.get(DevFn::Clear)));
         try!(self.send_cursor());
         try!(self.flush());
@@ -630,27 +559,19 @@ impl Terminal {
         Ok(())
     }
 
-    fn send_style(&mut self, fg: Style, bg: Style) -> Result<(), Error> {
-        if fg != self.lastfg || bg != self.lastbg {
+    fn send_style(&mut self, cell: Cell) -> Result<(), Error> {
+        if cell.fg() != self.laststyle.fg() || cell.bg() != self.laststyle.bg() || cell.attrs() != self.laststyle.attrs() {
             try!(self.outbuffer.write_all(&self.driver.get(DevFn::Reset)));
 
-            match fg.attr() {
+            match cell.attrs() {
                 Attr::Bold => try!(self.outbuffer.write_all(&self.driver.get(DevFn::Bold))),
                 Attr::Underline => try!(self.outbuffer.write_all(&self.driver.get(DevFn::Underline))),
                 Attr::Reverse => try!(self.outbuffer.write_all(&self.driver.get(DevFn::Reverse))),
                 _ => {},
             }
 
-            match bg.attr() {
-                Attr::Bold => try!(self.outbuffer.write_all(&self.driver.get(DevFn::Blink))),
-                Attr::Underline => {},
-                Attr::Reverse => try!(self.outbuffer.write_all(&self.driver.get(DevFn::Reverse))),
-                _ => {},
-            }
-
-            try!(self.write_sgr(fg.color(), bg.color()));
-            self.lastfg = fg;
-            self.lastbg = bg;
+            try!(self.write_sgr(cell.fg(), cell.bg()));
+            self.laststyle = cell;
         }
         Ok(())
     }
@@ -683,7 +604,8 @@ impl Terminal {
         self.backbuffer.resize(self.cols, self.rows, blank);
         self.frontbuffer.resize(self.cols, self.rows, blank);
         self.frontbuffer.clear(blank);
-        try!(self.send_clear(blank.fg(), blank.bg()));
+        try!(self.send_style(blank));
+        try!(self.send_clear());
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@ mod util;
 pub use core::terminal::Terminal;
 pub use core::cellbuffer::{
     Cell,
-    Style,
     Color,
     Attr,
 };


### PR DESCRIPTION
Remove `Style` in order to flatten `Cell` structure. Rather than `fg`
and `bg` each having both a `Color` and a `Attr`, they both become
straight up `Color` and we add a new `attrs` attribute to the `Cell`.

This is more in line with the underlying driver (the `term` module)
which doesn't apply its attribute to foreground or background. It's
always the whole cell that it affected.

It also makes working with the API a bit lighter. It could become
cumbersome to have to involve both `Style` and `Color` in order to
change foreground or background colors.

@cpjreynolds what do you think about this change? I wanted to try it out (hence this PR) because the more I work with rustty, the more I find the `Style` API needlessly heavy. So the other day, I dig in the code and see that `Attr` isn't really tied to either fg or bg in the underlying driver, so I think "why give us this trouble"? So here's a PR giving an idea of what it looks like without `Style`.