### PR TITLE
Circle example improvements

### DIFF
--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -9,15 +9,13 @@ const BLOCK: char = '\u{25AA}';
 const BUFF_ALIGN: usize = 35;
 
 fn write_word(term: &mut Terminal, row: usize, word: String) { 
-
+    // Helper function to write right-aligned text to the passed
+    // row, aligns via the BUFF_ALIGN constant
     let cols = term.cols() as usize;
 
-    for (idx, ch) in word.chars().enumerate() {
-        
+    for (idx, ch) in word.chars().enumerate() { 
         let x = cols - BUFF_ALIGN;
-        
-        let mut cell = &mut term[(x as usize + idx, row)];
-        cell.set_ch(ch);
+        term[(x + idx, row)].set_ch(ch);
     }
 }
 
@@ -34,11 +32,14 @@ fn main() {
             }
         }
 
+        // Grab the size of the console, and reserve 4 rows at the bottom
+        // to write text to. These bottom 4 will NOT be rendered
         let (cols, rows) = term.size();
         let (cols, rows) = (cols as isize, (rows - 4) as isize);
 
         let (a, b) = (cols / 2, rows / 2);
 
+        // Main render loop, draws the circle
         for i in 0..cols*rows {
             let y = i as isize / cols;
             let x = i as isize % cols;
@@ -52,11 +53,14 @@ fn main() {
             }
         }
 
+        // Render text at bottom
         let i = cols*rows;
         let y = i as isize / cols;
         write_word(&mut term, y as usize, "+ -> Increase Radius".to_string());
         write_word(&mut term, (y+1) as usize, "- -> Decrease Radius".to_string());
         write_word(&mut term, (y+2) as usize, "q -> Quit".to_string());
+        
+        // Swap buffers
         term.swap_buffers().unwrap();
     }
 }

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -9,27 +9,29 @@ const BLOCK: char = '\u{25AA}';
 
 fn main() {
     let mut term = Terminal::new().unwrap();
-    let mut radius = 10isize;
+    let mut radius = 10u32;
     'main: loop {
         while let Some(Event::Key(ch)) = term.get_event(0).unwrap() {
             match ch {
                 'q' => break 'main,
-                '+' => radius += 1,
-                '-' => radius -= 1,
+                '+' => radius = radius.saturating_add(1),
+                '-' => radius = radius.saturating_sub(1),
                 _ => {},
             }
         }
 
         let (cols, rows) = term.size();
-        let (cols, rows) = (cols as isize, rows as isize);
+        let (cols, rows) = (cols as isize, (rows - 3) as isize);
 
         let (a, b) = (cols / 2, rows / 2);
 
-        for (i, cell) in term.iter_mut().enumerate() {
+        for i in 0..cols*rows {
             let y = i as isize / cols;
             let x = i as isize % cols;
 
-            if ((x - a).pow(2) + (y - b).pow(2)) <= radius.pow(2) {
+            let mut cell = &mut term[(x as usize, y as usize)];
+
+            if ((x - a).pow(2)/4 + (y - b).pow(2)) <= radius.pow(2) as isize {
                 cell.set_ch(BLOCK);
             } else {
                 cell.set_ch(' ');

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -6,6 +6,20 @@ use rustty::{
 };
 
 const BLOCK: char = '\u{25AA}';
+const BUFF_ALIGN: usize = 35;
+
+fn write_word(term: &mut Terminal, row: usize, word: String) { 
+
+    let cols = term.cols() as usize;
+
+    for (idx, ch) in word.chars().enumerate() {
+        
+        let x = cols - BUFF_ALIGN;
+        
+        let mut cell = &mut term[(x as usize + idx, row)];
+        cell.set_ch(ch);
+    }
+}
 
 fn main() {
     let mut term = Terminal::new().unwrap();
@@ -21,7 +35,7 @@ fn main() {
         }
 
         let (cols, rows) = term.size();
-        let (cols, rows) = (cols as isize, (rows - 3) as isize);
+        let (cols, rows) = (cols as isize, (rows - 4) as isize);
 
         let (a, b) = (cols / 2, rows / 2);
 
@@ -37,6 +51,12 @@ fn main() {
                 cell.set_ch(' ');
             }
         }
+
+        let i = cols*rows;
+        let y = i as isize / cols;
+        write_word(&mut term, y as usize, "+ -> Increase Radius".to_string());
+        write_word(&mut term, (y+1) as usize, "- -> Decrease Radius".to_string());
+        write_word(&mut term, (y+2) as usize, "q -> Quit".to_string());
         term.swap_buffers().unwrap();
     }
 }


### PR DESCRIPTION
The circle example is pretty cool, and could benefit from some text addition and small refactoring! What I changed

* The equation of the circle was changed to 
`(x - a).pow(2) / 4 + (y - b).pow(2)` The addition of ` / 4` takes into account that rows and columns are not evenly spaced in terminals. The distance between rows is much greater than the distance between each column for the terminal cells, this gives it a more circular shape.
* Decreasing the Radius no longer works beyond 1 by use of `saturating_sub`
* Text at the bottom of the screen lists controls, which are rendered through a simple write_out function
* Small refactoring

Picture of new look
![screenshot - 10072015 - 03 56 14 pm](https://cloud.githubusercontent.com/assets/1827631/10349456/95ccd454-6d0c-11e5-8424-17d5f8db7dd5.png)
