### PR TITLE
Implement Vertical aligning of buttons, subset drawing and new example

### DIFF
--- a/examples/buttonlayout.rs
+++ b/examples/buttonlayout.rs
@@ -4,6 +4,7 @@ use rustty::{
     Terminal,
     Event,
 };
+
 use rustty::ui::{
     Painter,
     Dialog,
@@ -11,38 +12,89 @@ use rustty::ui::{
     Alignable,
     HorizontalAlign,
     VerticalAlign,
+    ButtonLayout
 };
 
 fn create_maindlg() -> Dialog {
-    let mut maindlg = Dialog::new(60, 10);
+    // Create a dialog window 60 units wide and 12 units high
+    let mut maindlg = Dialog::new(60, 12);
+
+    // Text and alignment data to be used for displaying to dialog
     let s = "Hello! This is a showcase of the ui module!";
+    let s2 = "Here's a vertical layout configuration.";
     let x = maindlg.window().halign_line(s, HorizontalAlign::Middle, 1);
+    let x2 = maindlg.window().halign_line(s2, HorizontalAlign::Middle, 0);
     maindlg.window_mut().printline(x, 2, s);
+    maindlg.window_mut().printline(x2, 3, s2);
     
+    // Create the left column of buttons, these are buttons 0, 1, 2
     maindlg.add_button("Foo", 'f', DialogResult::Custom(1));
     maindlg.add_button("Bar", 'b', DialogResult::Custom(2));
     maindlg.add_button("Quit", 'q', DialogResult::Ok);
-    maindlg.draw_buttons_subset(0, 3, 1);
+    maindlg.draw_buttons_subset(0, 3, ButtonLayout::Vertical(HorizontalAlign::Left));
 
-    maindlg.add_button("Quu", 'q', DialogResult::Ok);
-    maindlg.add_button("Too", 't', DialogResult::Ok);
-    maindlg.add_button("Boo", 'b', DialogResult::Ok);
-    maindlg.draw_buttons_subset(3, 6, 2);
+    // Create the middle column of buttons, these are buttons 3, 4, 5
+    maindlg.add_button("Juu", 'j', DialogResult::Custom(3));
+    maindlg.add_button("Too", 't', DialogResult::Custom(4));
+    maindlg.add_button("Boo", 'b', DialogResult::Custom(5));
+    maindlg.draw_buttons_subset(3, 6, ButtonLayout::Vertical(HorizontalAlign::Middle));
 
+    // Create the right column of buttons, these are buttons 6, 7, 8
+    maindlg.add_button("Yhh", 'y', DialogResult::Custom(6));
+    maindlg.add_button("Vpp", 'v', DialogResult::Custom(7));
+    maindlg.add_button("Wgg", 'w', DialogResult::Custom(8));
+    maindlg.draw_buttons_subset(6, 9, ButtonLayout::Vertical(HorizontalAlign::Right));
+
+    // Draw the outline for the dialog
     maindlg.window_mut().draw_box();
     maindlg
 }
 
+fn create_hdlg(cols: usize) -> Dialog {
+    // Create a dialog window that's as wide as the terminal, and 7 units high
+    let mut hdlg = Dialog::new(cols, 7);
+
+    // Text and alignment data to be used for displaying to dialog
+    let s = "Here's a horizontal layout configuration.";
+    let x = hdlg.window().halign_line(s, HorizontalAlign::Middle, 1);
+    hdlg.window_mut().printline(x, 2, s);
+
+    // Create a row of buttons to be displayed
+    hdlg.add_button("Lo", 'l', DialogResult::Ok);
+    hdlg.add_button("Yo", 'y', DialogResult::Ok);
+    hdlg.add_button("Ho", 'h', DialogResult::Ok);
+    hdlg.add_button("Uo", 'u', DialogResult::Ok);
+
+    // Draw all buttons horizontally, and draw outline of dialog
+    hdlg.draw_buttons(ButtonLayout::Horizontal(2));
+    hdlg.window_mut().draw_box();
+    hdlg
+}
+
+
 fn main() {
     let mut term = Terminal::new().unwrap();
     let mut maindlg = create_maindlg();
+    let mut hdlg = create_hdlg(term.cols());
+    // Align main dialog window with the middle of the screen, and hdlg with the bottom
     maindlg.window_mut().align(&term, HorizontalAlign::Middle, VerticalAlign::Middle, 0);
+    hdlg.window_mut().align(&term, HorizontalAlign::Middle, VerticalAlign::Bottom, 0);
     'main: loop {
         while let Some(Event::Key(ch)) = term.get_event(0).unwrap() {
             match maindlg.result_for_key(ch) {
                 Some(DialogResult::Ok) => break 'main,
                 Some(DialogResult::Custom(i)) => {
-                    let msg = if i == 1 { "Foo!" } else { "Bar!" };
+                    let msg = match i { 
+                        1   =>  "Foo!", 
+                        2   =>  "Bar!",
+                        3   =>  "Juu!",
+                        4   =>  "Too!",
+                        5   =>  "Boo!",
+                        6   =>  "Yhh!",
+                        7   =>  "Vpp!",
+                        8   =>  "Wgg!",
+                        _   =>  ""
+                    };
                     let w = maindlg.window_mut();
                     let x = w.halign_line(msg, HorizontalAlign::Middle, 1);
                     let y = w.valign_line(msg, VerticalAlign::Middle, 1);
@@ -52,7 +104,9 @@ fn main() {
             }
         }
 
+        // Draw widgets to screen
         maindlg.window().draw_into(&mut term);
+        hdlg.window().draw_into(&mut term);
         term.swap_buffers().unwrap();
     }
 }

--- a/examples/buttonlayout.rs
+++ b/examples/buttonlayout.rs
@@ -1,0 +1,59 @@
+extern crate rustty;
+
+use rustty::{
+    Terminal,
+    Event,
+};
+use rustty::ui::{
+    Painter,
+    Dialog,
+    DialogResult,
+    Alignable,
+    HorizontalAlign,
+    VerticalAlign,
+};
+
+fn create_maindlg() -> Dialog {
+    let mut maindlg = Dialog::new(60, 10);
+    let s = "Hello! This is a showcase of the ui module!";
+    let x = maindlg.window().halign_line(s, HorizontalAlign::Middle, 1);
+    maindlg.window_mut().printline(x, 2, s);
+    
+    maindlg.add_button("Foo", 'f', DialogResult::Custom(1));
+    maindlg.add_button("Bar", 'b', DialogResult::Custom(2));
+    maindlg.add_button("Quit", 'q', DialogResult::Ok);
+    maindlg.draw_buttons_subset(0, 3, 1);
+
+    maindlg.add_button("Quu", 'q', DialogResult::Ok);
+    maindlg.add_button("Too", 't', DialogResult::Ok);
+    maindlg.add_button("Boo", 'b', DialogResult::Ok);
+    maindlg.draw_buttons_subset(3, 6, 2);
+
+    maindlg.window_mut().draw_box();
+    maindlg
+}
+
+fn main() {
+    let mut term = Terminal::new().unwrap();
+    let mut maindlg = create_maindlg();
+    maindlg.window_mut().align(&term, HorizontalAlign::Middle, VerticalAlign::Middle, 0);
+    'main: loop {
+        while let Some(Event::Key(ch)) = term.get_event(0).unwrap() {
+            match maindlg.result_for_key(ch) {
+                Some(DialogResult::Ok) => break 'main,
+                Some(DialogResult::Custom(i)) => {
+                    let msg = if i == 1 { "Foo!" } else { "Bar!" };
+                    let w = maindlg.window_mut();
+                    let x = w.halign_line(msg, HorizontalAlign::Middle, 1);
+                    let y = w.valign_line(msg, VerticalAlign::Middle, 1);
+                    w.printline(x, y, msg);
+                },
+                _ => {},
+            }
+        }
+
+        maindlg.window().draw_into(&mut term);
+        term.swap_buffers().unwrap();
+    }
+}
+

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -11,6 +11,7 @@ use rustty::ui::{
     Alignable,
     HorizontalAlign,
     VerticalAlign,
+    ButtonLayout
 };
 
 fn create_maindlg() -> Dialog {
@@ -21,7 +22,7 @@ fn create_maindlg() -> Dialog {
     maindlg.add_button("Foo", 'f', DialogResult::Custom(1));
     maindlg.add_button("Bar", 'b', DialogResult::Custom(2));
     maindlg.add_button("Quit", 'q', DialogResult::Ok);
-    maindlg.draw_buttons();
+    maindlg.draw_buttons(ButtonLayout::Horizontal(2));
     maindlg.window_mut().draw_box();
     maindlg
 }

--- a/src/ui/dialog.rs
+++ b/src/ui/dialog.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
 use ui::layout::{
-    Alignable, 
-    HorizontalLayout, 
-    HorizontalAlign, 
+    Alignable,
+    HorizontalLayout,
+    HorizontalAlign,
     VerticalAlign,
     VerticalLayout,
     ButtonLayout,
@@ -85,7 +85,7 @@ impl Dialog {
             match layout {
                 ButtonLayout::Vertical(g)   => {
                     let mut l = VerticalLayout::new(elems);
-                    l.align(&self.window, g, VerticalAlign::Bottom, (u-i-1));
+                    l.align(&self.window, g, VerticalAlign::Bottom, 1);
                     l.align_elems();
                 },
                 ButtonLayout::Horizontal(i) => {

--- a/src/ui/dialog.rs
+++ b/src/ui/dialog.rs
@@ -1,6 +1,13 @@
 use std::collections::HashMap;
 
-use ui::layout::{Alignable, HorizontalLayout, HorizontalAlign, VerticalAlign};
+use ui::layout::{
+    Alignable, 
+    HorizontalLayout, 
+    HorizontalAlign, 
+    VerticalAlign,
+    VerticalLayout,
+    ButtonLayout,
+};
 use ui::widget::Widget;
 use ui::button::{create_button};
 
@@ -48,25 +55,57 @@ impl Dialog {
         }
     }
 
-    pub fn draw_buttons(&mut self) {
+    pub fn draw_buttons(&mut self, layout: ButtonLayout) {
         fn f(b: &mut Widget) -> &mut Alignable { &mut *b }
         {
-            let elems = self.buttons.iter_mut().map(f).collect();
-            let mut l = HorizontalLayout::new(elems, 2);
-            l.align(&self.window, HorizontalAlign::Middle, VerticalAlign::Bottom, 1);
-            l.align_elems();
+            let elems: Vec<&mut Alignable> = self.buttons.iter_mut().map(f).collect();
+            match layout {
+                ButtonLayout::Vertical(g)   => {
+                    let length = elems.len();
+                    let mut l = VerticalLayout::new(elems);
+                    l.align(&self.window, g, VerticalAlign::Bottom, length);
+                    l.align_elems();
+                },
+                ButtonLayout::Horizontal(i) => {
+                    let mut l = HorizontalLayout::new(elems, 2);
+                    l.align(&self.window, HorizontalAlign::Middle, VerticalAlign::Bottom, i);
+                    l.align_elems();
+                }
+            }
         }
         for b in self.buttons.iter() {
             b.draw_into(&mut self.window);
         }
     }
 
-    pub fn draw_buttons_subset(&mut self, i: usize, u: usize, offset: usize) {
+    pub fn draw_buttons_subset(&mut self, i: usize, u: usize, layout: ButtonLayout) {
         fn f(b: &mut Widget) -> &mut Alignable { &mut *b }
         {
             let elems = self.buttons[i..u].iter_mut().map(f).collect();
-            let mut a = HorizontalLayout::new(elems, 2);
-            a.align(&self.window, HorizontalAlign::Middle, VerticalAlign::Bottom, offset);
+            match layout {
+                ButtonLayout::Vertical(g)   => {
+                    let mut l = VerticalLayout::new(elems);
+                    l.align(&self.window, g, VerticalAlign::Bottom, (u-i-1));
+                    l.align_elems();
+                },
+                ButtonLayout::Horizontal(i) => {
+                    let mut l = HorizontalLayout::new(elems, 2);
+                    l.align(&self.window, HorizontalAlign::Middle, VerticalAlign::Bottom, i);
+                    l.align_elems();
+                }
+            }
+        }
+        for b in self.buttons[i..u].iter() {
+            b.draw_into(&mut self.window);
+        }
+    }
+    pub fn gdraw_buttons_subset(&mut self, i: usize, u: usize, offset: usize) {
+        fn f(b: &mut Widget) -> &mut Alignable { &mut *b }
+        {
+            let elems = self.buttons[i..u].iter_mut().map(f).collect();
+            let mut a = VerticalLayout::new(elems);
+            //a.halign(&self.window, HorizontalAlign::Middle, offset);
+            a.align(&self.window, HorizontalAlign::Left, VerticalAlign::Bottom, offset);
             a.align_elems();
         }
         for b in self.buttons[i..u].iter() {

--- a/src/ui/dialog.rs
+++ b/src/ui/dialog.rs
@@ -99,17 +99,4 @@ impl Dialog {
             b.draw_into(&mut self.window);
         }
     }
-    pub fn gdraw_buttons_subset(&mut self, i: usize, u: usize, offset: usize) {
-        fn f(b: &mut Widget) -> &mut Alignable { &mut *b }
-        {
-            let elems = self.buttons[i..u].iter_mut().map(f).collect();
-            let mut a = VerticalLayout::new(elems);
-            //a.halign(&self.window, HorizontalAlign::Middle, offset);
-            a.align(&self.window, HorizontalAlign::Left, VerticalAlign::Bottom, offset);
-            a.align_elems();
-        }
-        for b in self.buttons[i..u].iter() {
-            b.draw_into(&mut self.window);
-        }
-    }
 }

--- a/src/ui/dialog.rs
+++ b/src/ui/dialog.rs
@@ -60,4 +60,17 @@ impl Dialog {
             b.draw_into(&mut self.window);
         }
     }
+
+    pub fn draw_buttons_subset(&mut self, i: usize, u: usize, offset: usize) {
+        fn f(b: &mut Widget) -> &mut Alignable { &mut *b }
+        {
+            let elems = self.buttons[i..u].iter_mut().map(f).collect();
+            let mut a = HorizontalLayout::new(elems, 2);
+            a.align(&self.window, HorizontalAlign::Middle, VerticalAlign::Bottom, offset);
+            a.align_elems();
+        }
+        for b in self.buttons[i..u].iter() {
+            b.draw_into(&mut self.window);
+        }
+    }
 }

--- a/src/ui/dialog.rs
+++ b/src/ui/dialog.rs
@@ -56,26 +56,8 @@ impl Dialog {
     }
 
     pub fn draw_buttons(&mut self, layout: ButtonLayout) {
-        fn f(b: &mut Widget) -> &mut Alignable { &mut *b }
-        {
-            let elems: Vec<&mut Alignable> = self.buttons.iter_mut().map(f).collect();
-            match layout {
-                ButtonLayout::Vertical(g)   => {
-                    let length = elems.len();
-                    let mut l = VerticalLayout::new(elems);
-                    l.align(&self.window, g, VerticalAlign::Bottom, length);
-                    l.align_elems();
-                },
-                ButtonLayout::Horizontal(i) => {
-                    let mut l = HorizontalLayout::new(elems, 2);
-                    l.align(&self.window, HorizontalAlign::Middle, VerticalAlign::Bottom, i);
-                    l.align_elems();
-                }
-            }
-        }
-        for b in self.buttons.iter() {
-            b.draw_into(&mut self.window);
-        }
+        let button_count = self.buttons.len();
+        self.draw_buttons_subset(0, button_count, layout);
     }
 
     pub fn draw_buttons_subset(&mut self, i: usize, u: usize, layout: ButtonLayout) {

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -91,3 +91,51 @@ impl<'a> HasPosition for HorizontalLayout<'a> {
 
 impl<'a> Alignable for HorizontalLayout<'a> {}
 
+pub struct VerticalLayout<'a> {
+    origin: Pos,
+    size: Size,
+    inner_margin: usize,
+    elems: Vec<&'a mut Alignable>,
+}
+
+impl <'a> VerticalLayout<'a> {
+    pub fn new(elems: Vec<&mut Alignable>, inner_margin: usize) -> VerticalLayout {
+        let first_origin = elems.first().unwrap().origin();
+        let total_height = elemns.len() - 1;
+        let height = total_height + inner_margin * (elemns.len() - 1);
+        let width = 
+        VerticalLayout {
+            origin: first_origin,
+            size: (width, 1),
+            inner_margin: inner_margin,
+            elems: elems,
+        }
+    }
+
+    pub fn align_elems(&mut self) {
+        let (x, y) = self.origin();
+        let mut current_x = x;
+        for elem in self.elems.iter_mut() {
+            elem.set_origin((current_x, y));
+            current_x += elem.size().0 + self.inner_margin;
+        }
+    }
+}
+
+impl<'a> HasSize for VerticalLayout<'a> {
+    fn size(&self) -> Size {
+        self.size
+    }
+}
+
+impl<'a> HasPosition for VerticalLayout<'a> {
+    fn origin(&self) -> Pos {
+        self.origin
+    }
+
+    fn set_origin(&mut self, new_origin: Pos) {
+        self.origin = new_origin;
+    }
+}
+
+impl<'a> Alignable for VerticalLayout<'a> {}

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -12,6 +12,11 @@ pub enum HorizontalAlign {
     Right,
 }
 
+pub enum ButtonLayout {
+    Vertical(HorizontalAlign),
+    Horizontal(usize)
+}
+
 pub trait Alignable: HasSize + HasPosition {
     fn halign(&mut self, parent: &HasSize, halign: HorizontalAlign, margin: usize) {
         let (cols, _) = self.size();
@@ -94,30 +99,27 @@ impl<'a> Alignable for HorizontalLayout<'a> {}
 pub struct VerticalLayout<'a> {
     origin: Pos,
     size: Size,
-    inner_margin: usize,
     elems: Vec<&'a mut Alignable>,
 }
 
 impl <'a> VerticalLayout<'a> {
-    pub fn new(elems: Vec<&mut Alignable>, inner_margin: usize) -> VerticalLayout {
+    pub fn new(elems: Vec<&mut Alignable>) -> VerticalLayout {
         let first_origin = elems.first().unwrap().origin();
-        let total_height = elemns.len() - 1;
-        let height = total_height + inner_margin * (elemns.len() - 1);
-        let width = 
+        let height = elems.len() - 1;
+        let width = elems.iter().map(|s| s.size().0).max().unwrap();
         VerticalLayout {
             origin: first_origin,
-            size: (width, 1),
-            inner_margin: inner_margin,
+            size: (width, height),
             elems: elems,
         }
     }
 
     pub fn align_elems(&mut self) {
         let (x, y) = self.origin();
-        let mut current_x = x;
+        let mut current_y = y;
         for elem in self.elems.iter_mut() {
-            elem.set_origin((current_x, y));
-            current_x += elem.size().0 + self.inner_margin;
+            elem.set_origin((x, current_y));
+            current_y += 1; 
         }
     }
 }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -105,7 +105,7 @@ pub struct VerticalLayout<'a> {
 impl <'a> VerticalLayout<'a> {
     pub fn new(elems: Vec<&mut Alignable>) -> VerticalLayout {
         let first_origin = elems.first().unwrap().origin();
-        let height = elems.len() - 1;
+        let height = elems.len();
         let width = elems.iter().map(|s| s.size().0).max().unwrap();
         VerticalLayout {
             origin: first_origin,
@@ -119,7 +119,7 @@ impl <'a> VerticalLayout<'a> {
         let mut current_y = y;
         for elem in self.elems.iter_mut() {
             elem.set_origin((x, current_y));
-            current_y += 1; 
+            current_y += 1;
         }
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,7 +5,8 @@ mod button;
 mod dialog;
 
 pub use ui::painter::Painter;
-pub use ui::layout::{Alignable, HorizontalAlign, VerticalAlign, HorizontalLayout};
+pub use ui::layout::{Alignable, HorizontalAlign, 
+                     VerticalAlign, HorizontalLayout, ButtonLayout};
 pub use ui::widget::Widget;
 pub use ui::button::{create_button};
 pub use ui::dialog::{Dialog, DialogResult};


### PR DESCRIPTION
List of things changed:

* New enum in *layout.rs*: ButtonLayout
  * A button can now support either horizontal or vertical alignment when drawing, so the button layout is passed as an argument into the function so draw can determine how to align these buttons
* New struct in *layout.rs*: `VerticalLayout`
  * To support vertical alignment, the VerticalLayout struct aligns buttons vertically
* Ability to draw only a subset of buttons present in the widget vector, allows for multiple rows of buttons and multiple columns of buttons
* New example to show button layout

The new prototype for drawing buttons it:
```
pub fn draw_buttons(&mut self, layout: ButtonLayout)
pub fn draw_buttons_subset(&mut self, i: usize, u: usize, layout: ButtonLayout)
```

layout can be of enum type
```
Vertical(HorizontalAlign) // left, middle, right
Horizontal(usize)            // row number
```
Things to note:

* Vertical and Horizontal align both automatically align to the **bottom** of the screen, this can probably be offered as a choice to the user? But I didn't want to have too many parameters
* buttonlayout.rs can probably just be merged into ui.rs, should I merge these or keep these separate?

Picture of new example:

![img](http://i.imgur.com/4nlDmQk.jpg)

thoughts? I haven't yet written documentation, as I don't know how well received this will be