### PR TITLE
Display exceptions via gag and stderr redirection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ nix = "0.4"
 term = "0.2"
 lazy_static = "0.1"
 libc = "0.1"
-
+gag = "0.1.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 extern crate term;
 extern crate nix;
 extern crate libc;
+extern crate gag;
 #[macro_use] extern crate lazy_static;
 
 mod core;


### PR DESCRIPTION
Proposed solution to https://github.com/cpjreynolds/rustty/issues/21

Ok, after days of looking into this subject I'm pretty sure there isn't a ~~nicer~~ non-library solution. Here's a rundown:

##### The Problem:

* When a panic occurs, the exception is printed to the screen and it begins unwinding. The problem is that the terminal needs to flush in order to return to the previous state before the program began running. This causes the exception message to be thrown away and leaves you with an unhelpful 'An unknown error has occurred' 


##### Solution:

EDIT: 

stderr redirection through [gag](https://stebalien.github.io/gag-rs/gag/). gag doesn't introduce any new limiting factors in terms of dependencies, and solves the headache of redirecting stderr.

Terminal will now contain a handle to the stderr redirection, and during flush if a panic is detected the handle will spill it contents into a string and print that string after the clear finishes. 

-----------------------

**Below is the old rant about finding a solution in the core library for this problem

There really isn't an intuitive solution like I had hoped, the biggest problem is that [stderr](https://doc.rust-lang.org/std/io/struct.Stderr.html) has absolutely zero mechanisms that will allow me to leech, copy, or redirect. This leads to there being no way to actually see what's happening to stderr as well as us having no control of it. Along the road I've found some future notes

* There's [set_panic](https://github.com/rust-lang/rust/blob/e3cd87241898cd88e4348e9c6142a03d8909c4e0/src/libstd/io/stdio.rs#L540) , but this is nightly only and it looks like only for internal use
* [Broadcast<>](https://doc.rust-lang.org/std/io/trait.Write.html#method.broadcast) looked promising, but it's also nightly only
* A [process](https://doc.rust-lang.org/std/process/index.html) can inherit stderr and be read from, however there is no way of creating a dummy child that only inherits stderr and does nothing
* Stderr is dumb 
* [This PR would solve our problem](https://github.com/rust-lang/rfcs/pull/1100) but who knows when this will be merged and made stable
* Attempt to use libc `dup2`  , but this is not cross-compatible

The only solution I've found is to just detect a panic during drop ... and not flush the screen. It turns out rust is incredibly picky with allows you to even touch their output streams, from my research there is currently no method (in stable) of copying / redirecting stderr output.

If you guys have any input, I'd love to hear it. Maybe I'm wrong and I'm missing some super obvious solution (I hope I am)

EDIT: The rust IRC is recommending the use of libc to create a separate thread to pipe stderr, which sounds like it may work but I have no expertise in the area of libc; may take a look later

EDIT EDIT: Wait a second, on to something