### PR TITLE
Compile error from mismatched types in driver.rs

### DIFF
--- a/src/core/driver.rs
+++ b/src/core/driver.rs
@@ -195,12 +195,12 @@ impl Driver {
 
         match dfn {
             DevFn::SetFg(attr) | DevFn::SetBg(attr) => {
-                let params = &[Param::Number(attr as i16)];
+                let params = &[Param::Number(attr as i32)];
                 let mut vars = Variables::new();
                 parm::expand(cap, params, &mut vars).unwrap()
             },
             DevFn::SetCursor(x, y) => {
-                let params = &[Param::Number(y as i16), Param::Number(x as i16)];
+                let params = &[Param::Number(y as i32), Param::Number(x as i32)];
                 let mut vars = Variables::new();
                 parm::expand(cap, params, &mut vars).unwrap()
             },


### PR DESCRIPTION
I'm not sure what the exact cause is, but I was suddenly unable to compile this on multiple machines (Rust v1.4) due to "expected i32, found i16" errors on a couple of lines in driver.rs.  I'm not very experienced with crates and dependencies and such, but I'd guess that one of the dependencies updated and caused the problem.  Sorry if I'm doing something wrong and the problem is on my end, but it was very reproducible for me and changing the i16s to i32s fixed it.