### PR TITLE
use Duration instead of millisecond value for timeouts

### DIFF
--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -1,20 +1,10 @@
 extern crate rustty;
 
-use rustty::{
-    Terminal,
-    Event,
-    HasSize,
-    CellAccessor
-};
+use std::time::Duration;
 
-use rustty::ui::{
-    Painter,
-    Dialog,
-    Widget,
-    Alignable,
-    HorizontalAlign,
-    VerticalAlign
-};
+use rustty::{Terminal, Event, HasSize, CellAccessor};
+
+use rustty::ui::{Painter, Dialog, Widget, Alignable, HorizontalAlign, VerticalAlign};
 
 const BLOCK: char = '\u{25AA}';
 
@@ -42,15 +32,15 @@ fn main() {
     // Align canvas to top left, and dialog to bottom right
     optiondlg.window_mut().align(&term, HorizontalAlign::Right, VerticalAlign::Bottom, 0);
     canvas.align(&term, HorizontalAlign::Left, VerticalAlign::Top, 0);
-    
+
     let mut radius = 10u32;
     'main: loop {
-        while let Some(Event::Key(ch)) = term.get_event(0).unwrap() {
+        while let Some(Event::Key(ch)) = term.get_event(Duration::new(0, 0)).unwrap() {
             match ch {
                 'q' => break 'main,
                 '+' => radius = radius.saturating_add(1),
                 '-' => radius = radius.saturating_sub(1),
-                _ => {},
+                _ => {}
             }
         }
         // Grab the size of the canvas
@@ -60,13 +50,13 @@ fn main() {
         let (a, b) = (cols / 2, rows / 2);
 
         // Main render loop, draws the circle to canvas
-        for i in 0..cols*rows {
+        for i in 0..cols * rows {
             let y = i as isize / cols;
             let x = i as isize % cols;
 
             let mut cell = canvas.get_mut(x as usize, y as usize).unwrap();
 
-            if ((x - a).pow(2)/4 + (y - b).pow(2)) <= radius.pow(2) as isize {
+            if ((x - a).pow(2) / 4 + (y - b).pow(2)) <= radius.pow(2) as isize {
                 cell.set_ch(BLOCK);
             } else {
                 cell.set_ch(' ');

--- a/examples/textedit.rs
+++ b/examples/textedit.rs
@@ -1,10 +1,8 @@
 extern crate rustty;
 
-use rustty::{
-    Terminal,
-    Event,
-    Color,
-};
+use std::time::Duration;
+
+use rustty::{Terminal, Event, Color};
 
 struct Cursor {
     pos: Position,
@@ -28,12 +26,12 @@ fn main() {
     term[(cursor.pos.x, cursor.pos.y)].set_bg(cursor.color);
     term.swap_buffers().unwrap();
     loop {
-        let evt = term.get_event(100).unwrap();
+        let evt = term.get_event(Duration::from_millis(100)).unwrap();
         if let Some(Event::Key(ch)) = evt {
             match ch {
                 '`' => {
                     break;
-                },
+                }
                 '\x7f' => {
                     cursor.lpos = cursor.pos;
                     if cursor.pos.x == 0 {
@@ -42,25 +40,25 @@ fn main() {
                         cursor.pos.x -= 1;
                     }
                     term[(cursor.pos.x, cursor.pos.y)].set_ch(' ');
-                },
+                }
                 '\r' => {
                     cursor.lpos = cursor.pos;
                     cursor.pos.x = 0;
                     cursor.pos.y += 1;
-                },
+                }
                 c @ _ => {
                     term[(cursor.pos.x, cursor.pos.y)].set_ch(c);
                     cursor.lpos = cursor.pos;
                     cursor.pos.x += 1;
-                },
+                }
             }
-            if cursor.pos.x >= term.cols()-1 {
+            if cursor.pos.x >= term.cols() - 1 {
                 term[(cursor.lpos.x, cursor.lpos.y)].set_bg(Color::Default);
                 cursor.lpos = cursor.pos;
                 cursor.pos.x = 0;
                 cursor.pos.y += 1;
             }
-            if cursor.pos.y >= term.rows()-1 {
+            if cursor.pos.y >= term.rows() - 1 {
                 term[(cursor.lpos.x, cursor.lpos.y)].set_bg(Color::Default);
                 cursor.lpos = cursor.pos;
                 cursor.pos.x = 0;
@@ -72,4 +70,3 @@ fn main() {
         }
     }
 }
-

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -1,17 +1,9 @@
 extern crate rustty;
 
-use rustty::{
-    Terminal,
-    Event,
-};
-use rustty::ui::{
-    Painter,
-    Dialog,
-    DialogResult,
-    Alignable,
-    HorizontalAlign,
-    VerticalAlign,
-};
+use std::time::Duration;
+
+use rustty::{Terminal, Event};
+use rustty::ui::{Painter, Dialog, DialogResult, Alignable, HorizontalAlign, VerticalAlign};
 
 fn create_maindlg() -> Dialog {
     let mut maindlg = Dialog::new(60, 10);
@@ -31,17 +23,21 @@ fn main() {
     let mut maindlg = create_maindlg();
     maindlg.window_mut().align(&term, HorizontalAlign::Middle, VerticalAlign::Middle, 0);
     'main: loop {
-        while let Some(Event::Key(ch)) = term.get_event(0).unwrap() {
+        while let Some(Event::Key(ch)) = term.get_event(Duration::new(0, 0)).unwrap() {
             match maindlg.result_for_key(ch) {
                 Some(DialogResult::Ok) => break 'main,
                 Some(DialogResult::Custom(i)) => {
-                    let msg = if i == 1 { "Foo!" } else { "Bar!" };
+                    let msg = if i == 1 {
+                        "Foo!"
+                    } else {
+                        "Bar!"
+                    };
                     let w = maindlg.window_mut();
                     let x = w.halign_line(msg, HorizontalAlign::Middle, 1);
                     let y = w.valign_line(msg, VerticalAlign::Middle, 1);
                     w.printline(x, y, msg);
-                },
-                _ => {},
+                }
+                _ => {}
             }
         }
 
@@ -49,4 +45,3 @@ fn main() {
         term.swap_buffers().unwrap();
     }
 }
-


### PR DESCRIPTION
The standard library now offers the `Duration` struct for the exact use case we have in `rustty`, the change updates the library to reflect this.