### PR TITLE
Dependency overhaul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustty"
-version = "0.1.11"
+version = "0.1.12"
 authors = ["Cole Reynolds <cpjreynolds@gmail.com>"]
 description = "A terminal UI library"
 documentation = "https://cpjreynolds.github.io/rustty"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ license = "MIT"
 keywords = ["terminal", "ui", "tui", "console", "tty"]
 
 [dependencies]
-nix = "0.5"
 term = "0.4"
 libc = "0.2"
 gag = "0.1"

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,7 +4,3 @@ pub mod driver;
 pub mod position;
 pub mod input;
 pub mod termctl;
-
-macro_rules! write_all {
-    ( $dst:expr, $src:expr ) => ( $dst.write_all($src) );
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,6 @@
 //! [README](https://github.com/cpjreynolds/rustty/blob/master/README.md)
 
 extern crate term;
-#[macro_use]
-extern crate nix;
 extern crate libc;
 extern crate gag;
 


### PR DESCRIPTION
Remove the dependency on the `nix` library in favor of using `libc`. This changes `rustty` to version `0.1.12`.