### PR TITLE
None timeout for Terminal::get_event

### DIFF
--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -35,7 +35,7 @@ fn main() {
 
     let mut radius = 10u32;
     'main: loop {
-        while let Some(Event::Key(ch)) = term.get_event(Duration::new(0, 0)).unwrap() {
+        while let Some(Event::Key(ch)) = term.get_event(Some(Duration::new(0, 0))).unwrap() {
             match ch {
                 'q' => break 'main,
                 '+' => radius = radius.saturating_add(1),

--- a/examples/textedit.rs
+++ b/examples/textedit.rs
@@ -26,7 +26,7 @@ fn main() {
     term[(cursor.pos.x, cursor.pos.y)].set_bg(cursor.color);
     term.swap_buffers().unwrap();
     loop {
-        let evt = term.get_event(Duration::from_millis(100)).unwrap();
+        let evt = term.get_event(Some(Duration::from_millis(100))).unwrap();
         if let Some(Event::Key(ch)) = evt {
             match ch {
                 '`' => {

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -23,7 +23,7 @@ fn main() {
     let mut maindlg = create_maindlg();
     maindlg.window_mut().align(&term, HorizontalAlign::Middle, VerticalAlign::Middle, 0);
     'main: loop {
-        while let Some(Event::Key(ch)) = term.get_event(Duration::new(0, 0)).unwrap() {
+        while let Some(Event::Key(ch)) = term.get_event(Some(Duration::new(0, 0))).unwrap() {
             match maindlg.result_for_key(ch) {
                 Some(DialogResult::Ok) => break 'main,
                 Some(DialogResult::Custom(i)) => {

--- a/src/core/input.rs
+++ b/src/core/input.rs
@@ -1,7 +1,7 @@
 /// An input event.
 ///
 /// An `Event` represents a single event from the underying terminal. At the moment no further
-/// processing is done on events and raw escape sequences will also be passed as `Key`s.:wq
+/// processing is done on events and raw escape sequences will also be passed as `Key`s.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Event {
     Key(char),


### PR DESCRIPTION
This is a breaking change. The timeout argument to get_event is now an Option. Passing it 'None' causes get_event to never timeout. Passing 'Some(duration)' times out after 'duration'.

The examples are updated to use the new interface.

Note that the documentation already specifies this behaviour so I didn't update it.

This is my first rust PR! Feedback is welcome.