### PR TITLE
Escape sequence handling

### DIFF
--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -35,7 +35,7 @@ fn main() {
 
     let mut radius = 10u32;
     'main: loop {
-        while let Some(Event::Key(ch)) = term.get_event(Some(Duration::new(0, 0))).unwrap() {
+        while let Some(Event::Char(ch)) = term.get_event(Some(Duration::new(0, 0))).unwrap() {
             match ch {
                 'q' => break 'main,
                 '+' => radius = radius.saturating_add(1),

--- a/examples/textedit.rs
+++ b/examples/textedit.rs
@@ -27,7 +27,7 @@ fn main() {
     term.swap_buffers().unwrap();
     loop {
         let evt = term.get_event(Some(Duration::from_millis(100))).unwrap();
-        if let Some(Event::Key(ch)) = evt {
+        if let Some(Event::Char(ch)) = evt {
             match ch {
                 '`' => {
                     break;

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -23,7 +23,7 @@ fn main() {
     let mut maindlg = create_maindlg();
     maindlg.window_mut().align(&term, HorizontalAlign::Middle, VerticalAlign::Middle, 0);
     'main: loop {
-        while let Some(Event::Key(ch)) = term.get_event(Some(Duration::new(0, 0))).unwrap() {
+        while let Some(Event::Char(ch)) = term.get_event(Some(Duration::new(0, 0))).unwrap() {
             match maindlg.result_for_key(ch) {
                 Some(DialogResult::Ok) => break 'main,
                 Some(DialogResult::Custom(i)) => {

--- a/src/core/driver.rs
+++ b/src/core/driver.rs
@@ -38,6 +38,8 @@ const KEYS: &'static [(Event, &'static str, &'static str)] = &[
     (Event::End, "key_end", "kend"),
 ];
 
+const ESCAPE: char = '\u{1b}';
+
 // String constants correspond to terminfo capnames and are used inside the module for convenience.
 const ENTER_CA: &'static str = "smcup";
 const EXIT_CA: &'static str = "rmcup";
@@ -188,6 +190,22 @@ impl Driver {
         }
 
         Ok(())
+    }
+
+    pub fn get_event(&self, buf: &String) -> Option<Event> {
+        let mut iter = buf.chars();
+        let first = iter.next().expect("got empty string");
+        let rest = iter.as_str();
+
+        if first == ESCAPE {
+            if rest.is_empty() {
+                Some(Event::Char(first))
+            } else {
+                self.escape_seq_map.get(buf).map(|r| *r)
+            }
+        } else {
+            Some(Event::Char(first))
+        }
     }
 
     // Returns the device specific escape sequence for the given `DevFn`.

--- a/src/core/driver.rs
+++ b/src/core/driver.rs
@@ -192,6 +192,11 @@ impl Driver {
         Ok(())
     }
 
+    // Returns an Event corresponding to the contents of 'buf' for the current terminal,
+    // or None if the buffer contents doesn't correspond to a known event.
+    //
+    // If this function returns None, it could indicate that the particular escape sequence
+    // hasn't been implemented by this driver, or that the contents of `buf` is garbled.
     pub fn get_event(&self, buf: &String) -> Option<Event> {
         let mut iter = buf.chars();
         let first = iter.next().expect("got empty string");
@@ -199,6 +204,7 @@ impl Driver {
 
         if first == ESCAPE {
             if rest.is_empty() {
+                // Return the literal escape character
                 Some(Event::Char(first))
             } else {
                 self.escape_seq_map.get(buf).map(|r| *r)

--- a/src/core/driver.rs
+++ b/src/core/driver.rs
@@ -39,6 +39,8 @@ const KEYS: &'static [(Event, &'static str, &'static str)] = &[
 // String constants correspond to terminfo capnames and are used inside the module for convenience.
 const ENTER_CA: &'static str = "smcup";
 const EXIT_CA: &'static str = "rmcup";
+const ENTER_XMIT: &'static str = "smkx";
+const EXIT_XMIT: &'static str = "rmkx";
 const SHOW_CURSOR: &'static str = "cnorm";
 const HIDE_CURSOR: &'static str = "civis";
 const SET_CURSOR: &'static str = "cup";
@@ -60,6 +62,8 @@ const SETBG: &'static str = "setab";
 // TODO: Optional functionality testing.
 const CAPABILITIES: &'static [&'static str] = &[ENTER_CA,
                                                 EXIT_CA,
+                                                ENTER_XMIT,
+                                                EXIT_XMIT,
                                                 SHOW_CURSOR,
                                                 HIDE_CURSOR,
                                                 SET_CURSOR,
@@ -79,6 +83,8 @@ const CAPABILITIES: &'static [&'static str] = &[ENTER_CA,
 pub enum DevFn {
     EnterCa,
     ExitCa,
+    EnterXmit,
+    ExitXmit,
     ShowCursor,
     HideCursor,
     SetCursor(usize, usize),
@@ -97,6 +103,8 @@ impl DevFn {
         match *self {
             DevFn::EnterCa => ENTER_CA,
             DevFn::ExitCa => EXIT_CA,
+            DevFn::EnterXmit => ENTER_XMIT,
+            DevFn::ExitXmit => EXIT_XMIT,
             DevFn::ShowCursor => SHOW_CURSOR,
             DevFn::HideCursor => HIDE_CURSOR,
             DevFn::SetCursor(..) => SET_CURSOR,

--- a/src/core/driver.rs
+++ b/src/core/driver.rs
@@ -7,31 +7,34 @@ use term::terminfo::TermInfo;
 use term::terminfo::parm;
 use term::terminfo::parm::{Param, Variables};
 
-// Terminfo keys. These are arrays because the terminfo database from the `term` crate sometimes
-// uses the variable name and othertimes the capname.
-//
-// Arrays are formatted as ["variable_name", "cap_name"].
-const KEY_F1: &'static [&'static str] = &["key_f1", "kf1"];
-const KEY_F2: &'static [&'static str] = &["key_f2", "kf2"];
-const KEY_F3: &'static [&'static str] = &["key_f3", "kf3"];
-const KEY_F4: &'static [&'static str] = &["key_f4", "kf4"];
-const KEY_F5: &'static [&'static str] = &["key_f5", "kf5"];
-const KEY_F6: &'static [&'static str] = &["key_f6", "kf6"];
-const KEY_F7: &'static [&'static str] = &["key_f7", "kf7"];
-const KEY_F8: &'static [&'static str] = &["key_f8", "kf8"];
-const KEY_F9: &'static [&'static str] = &["key_f9", "kf9"];
-const KEY_F10: &'static [&'static str] = &["key_f10", "kf10"];
-const KEY_F11: &'static [&'static str] = &["key_f11", "kf11"];
-const KEY_F12: &'static [&'static str] = &["key_f12", "kf12"];
-const KEY_UP: &'static [&'static str] = &["key_up", "kcuu1"];
-const KEY_DOWN: &'static [&'static str] = &["key_down", "kcud1"];
-const KEY_LEFT: &'static [&'static str] = &["key_left", "kcub1"];
-const KEY_RIGHT: &'static [&'static str] = &["key_right", "kcuf1"];
+use core::input::Event;
 
-// Array of terminal keys.
-const KEYS: &'static [&'static [&'static str]] = &[KEY_F1, KEY_F2, KEY_F3, KEY_F4, KEY_F5, KEY_F6,
-                                                   KEY_F7, KEY_F8, KEY_F9, KEY_F10, KEY_F11,
-                                                   KEY_F12, KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT];
+// Array of tuples of events and their corresponding terminal keys.
+// Tuples are of the form (event, variable_name, tuple_name).
+// Both the variable_name and cap_name are given since terminfo
+// uses a combination of variable and cap names.
+const KEYS: &'static [(Event, &'static str, &'static str)] = &[
+    (Event::Function(1), "key_f1", "kf1"),
+    (Event::Function(2), "key_f2", "kf2"),
+    (Event::Function(3), "key_f3", "kf3"),
+    (Event::Function(4), "key_f4", "kf4"),
+    (Event::Function(5), "key_f5", "kf5"),
+    (Event::Function(6), "key_f6", "kf6"),
+    (Event::Function(7), "key_f7", "kf7"),
+    (Event::Function(8), "key_f8", "kf8"),
+    (Event::Function(9), "key_f9", "kf9"),
+    (Event::Function(10), "key_f10", "kf10"),
+    (Event::Function(11), "key_f11", "kf11"),
+    (Event::Function(12), "key_f12", "kf12"),
+    (Event::Up, "key_up", "kcuu1"),
+    (Event::Down, "key_down", "kcud1"),
+    (Event::Left, "key_left", "kcub1"),
+    (Event::Right, "key_right", "kcuf1"),
+    (Event::PageUp, "key_ppage", "kpp"),
+    (Event::PageDown, "key_npage", "knp"),
+    (Event::Home, "key_home", "khome"),
+    (Event::End, "key_end", "kend"),
+];
 
 // String constants correspond to terminfo capnames and are used inside the module for convenience.
 const ENTER_CA: &'static str = "smcup";

--- a/src/core/input.rs
+++ b/src/core/input.rs
@@ -4,5 +4,5 @@
 /// processing is done on events and raw escape sequences will also be passed as `Key`s.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Event {
-    Key(char),
+    Char(char),     // Ascii characters including escape, delete, bell, etc
 }

--- a/src/core/input.rs
+++ b/src/core/input.rs
@@ -5,4 +5,13 @@
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Event {
     Char(char),     // Ascii characters including escape, delete, bell, etc
+    Function(u8),   // Function keys (eg. f1, f2, ...)
+    Left,
+    Right,
+    Up,
+    Down,
+    PageUp,
+    PageDown,
+    Home,
+    End,
 }

--- a/src/core/terminal.rs
+++ b/src/core/terminal.rs
@@ -162,6 +162,9 @@ impl Terminal {
         // Switch to alternate screen buffer. Writes the control code to the output buffer.
         try!(terminal.outbuffer.write_all(&terminal.driver.get(DevFn::EnterCa)));
 
+        // Put the terminal in transmit mode
+        try!(terminal.outbuffer.write_all(&terminal.driver.get(DevFn::EnterXmit)));
+
         // Hide cursor. Writes the control code to the output buffer.
         try!(terminal.outbuffer.write_all(&terminal.driver.get(DevFn::HideCursor)));
 
@@ -691,6 +694,7 @@ impl Drop for Terminal {
         self.outbuffer.write_all(&self.driver.get(DevFn::ShowCursor)).unwrap();
         self.outbuffer.write_all(&self.driver.get(DevFn::Reset)).unwrap();
         self.outbuffer.write_all(&self.driver.get(DevFn::Clear)).unwrap();
+        self.outbuffer.write_all(&self.driver.get(DevFn::ExitXmit)).unwrap();
         self.outbuffer.write_all(&self.driver.get(DevFn::ExitCa)).unwrap();
         self.flush().unwrap();
         self.termctl.reset().unwrap();

--- a/src/core/terminal.rs
+++ b/src/core/terminal.rs
@@ -612,7 +612,7 @@ impl Terminal {
             let mut n = 0;
             for ch in buf.chars() {
                 // Push each character onto the event queue and increment the count.
-                self.eventbuffer.push_back(Event::Key(ch));
+                self.eventbuffer.push_back(Event::Char(ch));
                 n += 1;
             }
             Ok(n)

--- a/src/core/terminal.rs
+++ b/src/core/terminal.rs
@@ -5,7 +5,6 @@ use std::fs::OpenOptions;
 use std::fs::File;
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
-use std::collections::VecDeque;
 use std::thread;
 use std::time::Duration;
 use std::ptr;
@@ -30,7 +29,6 @@ static SIGWINCH_STATUS: AtomicBool = ATOMIC_BOOL_INIT;
 static RUSTTY_STATUS: AtomicBool = ATOMIC_BOOL_INIT;
 
 type OutBuffer = Vec<u8>;
-type EventBuffer = VecDeque<Event>;
 
 /// A representation of the current terminal window.
 ///
@@ -66,7 +64,6 @@ pub struct Terminal {
     backbuffer: CellBuffer, // Internal backbuffer.
     frontbuffer: CellBuffer, // Internal frontbuffer.
     outbuffer: OutBuffer, // Internal output buffer.
-    eventbuffer: EventBuffer, // Event buffer.
     laststyle: Cell, // Last cell to have its style (fg, bg, attrs) written to the output buffer.
     cursor: Cursor, // Current cursor position.
     stderr_handle: BufferRedirect,
@@ -153,7 +150,6 @@ impl Terminal {
             backbuffer: CellBuffer::new(0, 0, cell),
             frontbuffer: CellBuffer::new(0, 0, cell),
             outbuffer: OutBuffer::with_capacity(32 * 1024),
-            eventbuffer: EventBuffer::with_capacity(128),
             laststyle: cell,
             cursor: Cursor::new(),
             stderr_handle: BufferRedirect::stderr().unwrap(),
@@ -461,21 +457,62 @@ impl Terminal {
     ///
     /// let evt = term.get_event(Some(Duration::from_secs(1))).unwrap();
     /// ```
-    pub fn get_event(&mut self, timeout: Option<Duration>) -> Result<Option<Event>, Error> {
-        // Check if the event buffer is empty.
-        if self.eventbuffer.is_empty() {
-            // Event buffer is empty, lets poll the terminal for events.
-            let nevts = try!(self.read_events(timeout));
-            if nevts == 0 {
-                // No events from the terminal either. Return none.
-                Ok(None)
-            } else {
-                // Got at least one event from the terminal. Pop from the front of the event queue.
-                Ok(self.eventbuffer.pop_front())
+    pub fn get_event(&mut self, maybe_timeout: Option<Duration>) -> Result<Option<Event>, Error> {
+        let nevts;
+        let timeout: *mut libc::timeval = match maybe_timeout {
+            None => ptr::null_mut(),
+            Some(timeout) => &mut libc::timeval {
+                tv_sec: timeout.as_secs() as libc::time_t,
+                tv_usec: (timeout.subsec_nanos() as libc::suseconds_t) / 1000,
             }
+        };
+        let rawfd = self.tty.as_raw_fd();
+        let nfds = rawfd + 1;
+
+        let mut rfds: libc::fd_set = unsafe { mem::zeroed() };
+        unsafe {
+            libc::FD_SET(rawfd, &mut rfds);
+        }
+
+        // Because the sigwinch handler will interrupt select, if select returns EINTR we loop
+        // and try again. All other errors will return normally.
+        loop {
+            let res = unsafe {
+                libc::select(nfds,
+                             &mut rfds,
+                             ptr::null_mut(),
+                             ptr::null_mut(),
+                             timeout)
+            };
+
+            if res == -1 {
+                let err = Error::last_os_error();
+
+                if err.kind() == ErrorKind::Interrupted {
+                    // Errno is EINTR, loop and try again.
+                    continue;
+                } else {
+                    // Error other than EINTR, return to caller.
+                    return Err(err);
+                }
+            } else {
+                nevts = res;
+                break;
+            }
+        }
+
+        if nevts == 0 {
+            // Select timed out. Return None.
+            assert!(maybe_timeout.is_some());
+            Ok(None)
         } else {
-            // There is at least one event in the buffer already. Pop and return it.
-            Ok(self.eventbuffer.pop_front())
+            // Input is available from the terminal.
+            // Get an iterator of chars over the input stream.
+            let mut buf = String::new();
+            try!(self.tty.read_to_string(&mut buf));
+
+            assert!(buf.len() > 0);
+            Ok(self.driver.get_event(&buf))
         }
     }
 
@@ -554,72 +591,6 @@ impl Terminal {
         try!(self.send_style(blank));
         try!(self.send_clear());
         Ok(())
-    }
-
-    /// Attempts to read any available events from the terminal into the event buffer, waiting for
-    /// the specified timeout for input to become available.
-    ///
-    /// Returns the number of events read into the buffer.
-    fn read_events(&mut self, maybe_timeout: Option<Duration>) -> Result<usize, Error> {
-        let nevts;
-        let timeout: *mut libc::timeval = match maybe_timeout {
-            None => ptr::null_mut(),
-            Some(timeout) => &mut libc::timeval {
-                tv_sec: timeout.as_secs() as libc::time_t,
-                tv_usec: (timeout.subsec_nanos() as libc::suseconds_t) / 1000,
-            }
-        };
-        let rawfd = self.tty.as_raw_fd();
-        let nfds = rawfd + 1;
-
-        let mut rfds: libc::fd_set = unsafe { mem::zeroed() };
-        unsafe {
-            libc::FD_SET(rawfd, &mut rfds);
-        }
-
-        // Because the sigwinch handler will interrupt select, if select returns EINTR we loop
-        // and try again. All other errors will return normally.
-        loop {
-            let res = unsafe {
-                libc::select(nfds,
-                             &mut rfds,
-                             ptr::null_mut(),
-                             ptr::null_mut(),
-                             timeout)
-            };
-
-            if res == -1 {
-                let err = Error::last_os_error();
-
-                if err.kind() == ErrorKind::Interrupted {
-                    // Errno is EINTR, loop and try again.
-                    continue;
-                } else {
-                    // Error other than EINTR, return to caller.
-                    return Err(err);
-                }
-            } else {
-                nevts = res;
-                break;
-            }
-        }
-
-        if nevts == 0 {
-            // No input available. Return None.
-            Ok(0)
-        } else {
-            // Input is available from the terminal.
-            // Get an iterator of chars over the input stream.
-            let mut buf = String::new();
-            try!(self.tty.read_to_string(&mut buf));
-            let mut n = 0;
-            for ch in buf.chars() {
-                // Push each character onto the event queue and increment the count.
-                self.eventbuffer.push_back(Event::Char(ch));
-                n += 1;
-            }
-            Ok(n)
-        }
     }
 
     fn flush(&mut self) -> Result<(), Error> {


### PR DESCRIPTION
This adds supports escape sequences including arrow keys, page up, page down, home and end, and should make it easy to add additional escape sequences. The main difficulty was the terminal not being in keypad transmit mode which was messing up arrow key escape sequences.

You mentioned you also planned to work on this, so apologies if this conflicts with something you were already working on.
