### PR TITLE
Fixed bug where stale cursor pos used in flush

### DIFF
--- a/src/core/terminal.rs
+++ b/src/core/terminal.rs
@@ -192,6 +192,9 @@ impl Terminal {
         // Invalidate the last cursor position.
         self.cursor.invalidate_last_pos();
 
+        // Prevent stale position moving into last_pos
+        self.cursor.set_pos(None);
+
         for y in 0..self.rows() {
             for x in 0..self.cols() {
                 if self.frontbuffer[(x, y)] == self.backbuffer[(x, y)] {


### PR DESCRIPTION
Hi

During a flush, if the first cell that gets written to (ie. the first cell whose contents has changed) is directly to the right of the last cell written to in the previous flush, the cursor position doesn't get updated as it's considered sequential. When the cell then gets written to, it seems like the output doesn't go to the correct place (it isn't visible at all). The fix is to clear the current cursor position at the start of a flush, so the first real write of a flush sets the cursor position, regardless of its position at the end of the previous flush.

To demonstrate this behaviour, try setting the first 2 cells of the terminal to
`**`
<flush>
`.*`
<flush>
`..`
<flush>

The terminal should still be displaying `.*` due to the problem I described.