### PR TITLE
Update term dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ license = "MIT"
 keywords = ["terminal", "ui", "tui", "console", "tty"]
 
 [dependencies]
-term = "0.4"
+term = "0.5"
 libc = "0.2"
 gag = "0.1"


### PR DESCRIPTION
Fixes #58. Update `term` dependency to 0.5 to pull in the fix for

```
StringError("terminal missing capability: \'smcup\'")
```