### PR TITLE
update term version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ license = "MIT"
 keywords = ["terminal", "ui", "tui", "console", "tty"]
 
 [dependencies]
-term = "0.4"
+term = "0.7"
 libc = "0.2"
 gag = "0.1"


### PR DESCRIPTION
When creating a `Terminal` instance, I got the following error (running PopOS 22.04 with default terminal):

    thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Custom { kind: NotFound, error: "terminal missing capability: 'smcup'" }', src/main.rs:12:44

I was able to fix this by simply updating the `term` dependency to its latest release (`0.7`). I thought it would be helpful to submit this PR as others may encounter the same issue in future.